### PR TITLE
feat: setup react-router

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "react-dom": "^19.0.0",
     "react-dropzone": "^14.3.8",
     "react-hot-toast": "^2.5.2",
+    "react-router": "^7.4.0",
     "react-tooltip": "^5.28.0",
     "tailwindcss": "^4.0.9"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -101,6 +101,9 @@ importers:
       react-hot-toast:
         specifier: ^2.5.2
         version: 2.5.2(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+      react-router:
+        specifier: ^7.4.0
+        version: 7.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       react-tooltip:
         specifier: ^5.28.0
         version: 5.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
@@ -1824,6 +1827,9 @@ packages:
   '@types/bn.js@5.1.6':
     resolution: {integrity: sha512-Xh8vSwUeMKeYYrj3cX4lGQgFSF/N03r+tv4AiLl1SucqV+uTQpxRcnM8AkXKHwYP9ZPXOYXRr2KPXpVlIvqh9w==}
 
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
   '@types/dns-packet@5.6.5':
     resolution: {integrity: sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==}
 
@@ -2156,6 +2162,10 @@ packages:
 
   convert-source-map@2.0.0:
     resolution: {integrity: sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==}
+
+  cookie@1.0.2:
+    resolution: {integrity: sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA==}
+    engines: {node: '>=18'}
 
   core-js-compat@3.41.0:
     resolution: {integrity: sha512-RFsU9LySVue9RTwdDVX/T0e2Y6jRYWXERKElIjpuEOEnxaXffI0X7RUwVzfYLfzuLXSNJDYoRYUAmRUcyln20A==}
@@ -3390,6 +3400,16 @@ packages:
     resolution: {integrity: sha512-jCvmsr+1IUSMUyzOkRcvnVbX3ZYC6g9TDrDbFuFmRDq7PD4yaGbLKNQL6k2jnArV8hjYxh7hVhAZB6s9HDGpZA==}
     engines: {node: '>=0.10.0'}
 
+  react-router@7.4.0:
+    resolution: {integrity: sha512-Y2g5ObjkvX3VFeVt+0CIPuYd9PpgqCslG7ASSIdN73LwA1nNWzcMLaoMRJfP3prZFI92svxFwbn7XkLJ+UPQ6A==}
+    engines: {node: '>=20.0.0'}
+    peerDependencies:
+      react: '>=18'
+      react-dom: '>=18'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react-tooltip@5.28.0:
     resolution: {integrity: sha512-R5cO3JPPXk6FRbBHMO0rI9nkUG/JKfalBSQfZedZYzmqaZQgq7GLzF8vcCWx6IhUCKg0yPqJhXIzmIO5ff15xg==}
     peerDependencies:
@@ -3528,6 +3548,9 @@ packages:
   serve-static@1.16.2:
     resolution: {integrity: sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==}
     engines: {node: '>= 0.8.0'}
+
+  set-cookie-parser@2.7.1:
+    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
 
   setprototypeof@1.2.0:
     resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
@@ -3711,6 +3734,9 @@ packages:
 
   tunnel-agent@0.6.0:
     resolution: {integrity: sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==}
+
+  turbo-stream@2.4.0:
+    resolution: {integrity: sha512-FHncC10WpBd2eOmGwpmQsWLDoK4cqsA/UT/GqNoaKOQnT8uzhtCbg3EoUDMvqpOSAI0S26mr0rkjzbOO6S3v1g==}
 
   type-detect@4.0.8:
     resolution: {integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==}
@@ -6543,6 +6569,8 @@ snapshots:
     dependencies:
       '@types/node': 22.13.8
 
+  '@types/cookie@0.6.0': {}
+
   '@types/dns-packet@5.6.5':
     dependencies:
       '@types/node': 22.13.8
@@ -6949,6 +6977,8 @@ snapshots:
   convert-hrtime@5.0.0: {}
 
   convert-source-map@2.0.0: {}
+
+  cookie@1.0.2: {}
 
   core-js-compat@3.41.0:
     dependencies:
@@ -8424,6 +8454,16 @@ snapshots:
 
   react-refresh@0.14.2: {}
 
+  react-router@7.4.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
+    dependencies:
+      '@types/cookie': 0.6.0
+      cookie: 1.0.2
+      react: 19.0.0
+      set-cookie-parser: 2.7.1
+      turbo-stream: 2.4.0
+    optionalDependencies:
+      react-dom: 19.0.0(react@19.0.0)
+
   react-tooltip@5.28.0(react-dom@19.0.0(react@19.0.0))(react@19.0.0):
     dependencies:
       '@floating-ui/dom': 1.6.13
@@ -8587,6 +8627,8 @@ snapshots:
       send: 0.19.0
     transitivePeerDependencies:
       - supports-color
+
+  set-cookie-parser@2.7.1: {}
 
   setprototypeof@1.2.0: {}
 
@@ -8756,6 +8798,8 @@ snapshots:
   tunnel-agent@0.6.0:
     dependencies:
       safe-buffer: 5.2.1
+
+  turbo-stream@2.4.0: {}
 
   type-detect@4.0.8: {}
 

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,17 +1,11 @@
 import type { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 import { RefreshCw } from "lucide-react";
 import { useMemo, useState } from "react";
+import { Link, Outlet } from "react-router";
 import { GlobalCtxProvider } from "./GlobalCtxProvider";
 import { ConnectWallet } from "./components/ConnectWallet";
 import { COLLATOR_LOCAL_RPC_URL } from "./lib/consts";
 import { setupTypeRegistry } from "./lib/registry";
-import { DealPreparation } from "./pages/DealPreparation";
-import { Download } from "./pages/Download";
-
-enum FlowStatus {
-  DealPreparation = 0,
-  Download = 1,
-}
 
 // TODO: this component should be red if it fails to connect
 function WsAddressInput({ onChange }: { onChange: (newValue: string) => void }) {
@@ -42,44 +36,9 @@ function WsAddressInput({ onChange }: { onChange: (newValue: string) => void }) 
 }
 
 function App() {
-  const [flowStatus, setFlowStatus] = useState(FlowStatus.DealPreparation);
-
   const [accounts, setAccounts] = useState<InjectedAccountWithMeta[]>([]);
   const [selectedAccount, setSelectedAccount] = useState<InjectedAccountWithMeta | null>(null);
   const [wsAddress, setWsAddress] = useState(COLLATOR_LOCAL_RPC_URL);
-
-  const Flow = () => {
-    // If no accounts are connected, show the connect wallet page regardless of flow status
-    if (accounts.length === 0) {
-      return <ConnectWallet onConnect={setAccounts} />;
-    }
-
-    switch (flowStatus) {
-      case FlowStatus.DealPreparation: {
-        return (
-          <>
-            <DealPreparation
-              accounts={accounts}
-              selectedAccount={selectedAccount}
-              onSelectAccount={setSelectedAccount}
-            />
-            <div className="flex justify-left mt-4">
-              <button
-                type="button"
-                onClick={() => setFlowStatus(FlowStatus.Download)}
-                className="px-4 py-2 bg-gray-200 hover:bg-gray-300 rounded-sm"
-              >
-                Download Files
-              </button>
-            </div>
-          </>
-        );
-      }
-      case FlowStatus.Download: {
-        return <Download />;
-      }
-    }
-  };
 
   const registry = useMemo(() => setupTypeRegistry(), []);
 
@@ -88,9 +47,21 @@ function App() {
       <div className="m-8">
         <div className="flex mb-4 items-center">
           <h1 className="grow text-xl font-bold">📦 Delia</h1>
+          <div className="flex items-center mr-6">
+            <Link to="/" className="mr-4 px-3 py-1 bg-gray-200 hover:bg-gray-300 rounded-sm">
+              Deal Creation
+            </Link>
+            <Link to="/download" className="px-3 py-1 bg-gray-200 hover:bg-gray-300 rounded-sm">
+              Download
+            </Link>
+          </div>
           <WsAddressInput onChange={setWsAddress} />
         </div>
-        <Flow />
+        {accounts.length === 0 ? (
+          <ConnectWallet onConnect={setAccounts} />
+        ) : (
+          <Outlet context={{ accounts, selectedAccount, setSelectedAccount }} />
+        )}
       </div>
     </GlobalCtxProvider>
   );

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,11 +1,14 @@
 import type { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 import { RefreshCw } from "lucide-react";
 import { useMemo, useState } from "react";
-import { Link, Outlet } from "react-router";
+import { Link, Outlet, useLocation } from "react-router";
 import { GlobalCtxProvider } from "./GlobalCtxProvider";
 import { ConnectWallet } from "./components/ConnectWallet";
 import { COLLATOR_LOCAL_RPC_URL } from "./lib/consts";
 import { setupTypeRegistry } from "./lib/registry";
+
+const DEAL_CREATION_PATH = "/";
+const DOWNLOAD_PATH = "/download";
 
 // TODO: this component should be red if it fails to connect
 function WsAddressInput({ onChange }: { onChange: (newValue: string) => void }) {
@@ -40,6 +43,7 @@ function App() {
   const [selectedAccount, setSelectedAccount] = useState<InjectedAccountWithMeta | null>(null);
   const [wsAddress, setWsAddress] = useState(COLLATOR_LOCAL_RPC_URL);
 
+  const location = useLocation();
   const registry = useMemo(() => setupTypeRegistry(), []);
 
   return (
@@ -48,12 +52,20 @@ function App() {
         <div className="flex mb-4 items-center">
           <h1 className="grow text-xl font-bold">📦 Delia</h1>
           <div className="flex items-center mr-6">
-            <Link to="/" className="mr-4 px-3 py-1 bg-gray-200 hover:bg-gray-300 rounded-sm">
-              Deal Creation
-            </Link>
-            <Link to="/download" className="px-3 py-1 bg-gray-200 hover:bg-gray-300 rounded-sm">
-              Download
-            </Link>
+            {location.pathname === DEAL_CREATION_PATH ? (
+              <></>
+            ) : (
+              <Link to="/" className="px-3 py-1 bg-gray-200 hover:bg-gray-300 rounded-sm">
+                Deal Creation
+              </Link>
+            )}
+            {location.pathname === DOWNLOAD_PATH ? (
+              <></>
+            ) : (
+              <Link to="/download" className="px-3 py-1 bg-gray-200 hover:bg-gray-300 rounded-sm">
+                Download
+              </Link>
+            )}
           </div>
           <WsAddressInput onChange={setWsAddress} />
         </div>

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,12 +1,32 @@
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
+import { RouterProvider, createBrowserRouter } from "react-router";
 import "./index.css";
 import "react-tooltip/dist/react-tooltip.css";
 import App from "./App.tsx";
+import { DealPreparation } from "./pages/DealPreparation";
+import { Download } from "./pages/Download";
+
+const router = createBrowserRouter([
+  {
+    path: "/",
+    element: <App />,
+    children: [
+      {
+        path: "/",
+        element: <DealPreparation />,
+      },
+      {
+        path: "/download",
+        element: <Download />,
+      },
+    ],
+  },
+]);
 
 // biome-ignore lint/style/noNonNullAssertion: If there is no `root` there is no page
 createRoot(document.getElementById("root")!).render(
   <StrictMode>
-    <App />
-  </StrictMode>
+    <RouterProvider router={router} />
+  </StrictMode>,
 );

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -10,15 +10,15 @@ import { Download } from "./pages/Download";
 const router = createBrowserRouter([
   {
     path: "/",
-    element: <App />,
+    Component: App,
     children: [
       {
-        path: "/",
-        element: <DealPreparation />,
+        index: true,
+        Component: DealPreparation,
       },
       {
         path: "/download",
-        element: <Download />,
+        Component: Download,
       },
     ],
   },

--- a/src/pages/DealPreparation.tsx
+++ b/src/pages/DealPreparation.tsx
@@ -163,8 +163,8 @@ export function DealPreparation() {
 
   return (
     <>
-      <div className="flex">
-        <div className="bg-white rounded-lg shadow p-6 mb-4">
+      <div className="flex bg-white rounded-lg shadow p-6 mb-4">
+        <div>
           <h2 className="text-xl font-bold mb-4">Deal Creation</h2>
           <DealProposalForm
             dealProposal={dealProposal}

--- a/src/pages/DealPreparation.tsx
+++ b/src/pages/DealPreparation.tsx
@@ -1,6 +1,7 @@
 import type { InjectedAccountWithMeta } from "@polkadot/extension-inject/types";
 import { useCallback, useState } from "react";
 import { Toaster, toast } from "react-hot-toast";
+import { useOutletContext } from "react-router";
 import { useCtx } from "../GlobalCtx";
 import { DealProposalForm } from "../components/DealProposalForm";
 import { ProviderSelector } from "../components/ProviderSelector";
@@ -18,15 +19,15 @@ import { callProposeDeal, callPublishDeal } from "../lib/jsonRpc";
 import { queryPeerId } from "../lib/requestResponse";
 import type { StorageProviderInfo } from "../lib/storageProvider";
 
-export function DealPreparation({
-  accounts,
-  selectedAccount,
-  onSelectAccount,
-}: {
+type OutletContextType = {
   accounts: InjectedAccountWithMeta[];
   selectedAccount: InjectedAccountWithMeta | null;
-  onSelectAccount: (account: InjectedAccountWithMeta) => void;
-}) {
+  setSelectedAccount: (account: InjectedAccountWithMeta) => void;
+};
+
+export function DealPreparation() {
+  const { accounts, selectedAccount, setSelectedAccount } = useOutletContext<OutletContextType>();
+
   const [dealProposal, setDealProposal] = useState<InputFields>({
     ...DEFAULT_INPUT,
     client: selectedAccount?.address || null,
@@ -170,7 +171,7 @@ export function DealPreparation({
           selectedFile={dealFile}
           accounts={accounts}
           selectedAccount={selectedAccount}
-          onSelectAccount={onSelectAccount}
+          onSelectAccount={setSelectedAccount}
         />
         <div className="bg-black mx-8 min-w-px max-w-px" />
         <ProviderSelector

--- a/src/pages/DealPreparation.tsx
+++ b/src/pages/DealPreparation.tsx
@@ -164,15 +164,19 @@ export function DealPreparation() {
   return (
     <>
       <div className="flex">
-        <DealProposalForm
-          dealProposal={dealProposal}
-          onChange={setDealProposal}
-          onFileSelect={setDealFile}
-          selectedFile={dealFile}
-          accounts={accounts}
-          selectedAccount={selectedAccount}
-          onSelectAccount={setSelectedAccount}
-        />
+        <div className="bg-white rounded-lg shadow p-6 mb-4">
+          <h2 className="text-xl font-bold mb-4">Deal Creation</h2>
+          <DealProposalForm
+            dealProposal={dealProposal}
+            onChange={setDealProposal}
+            onFileSelect={setDealFile}
+            selectedFile={dealFile}
+            accounts={accounts}
+            selectedAccount={selectedAccount}
+            onSelectAccount={setSelectedAccount}
+          />
+          <Submit />
+        </div>
         <div className="bg-black mx-8 min-w-px max-w-px" />
         <ProviderSelector
           providers={providers}
@@ -181,7 +185,6 @@ export function DealPreparation() {
           onSelectProvider={updateProviderSelection}
         />
       </div>
-      <Submit />
       <Toaster position="bottom-right" reverseOrder={true} />
     </>
   );

--- a/src/pages/Download.tsx
+++ b/src/pages/Download.tsx
@@ -137,7 +137,7 @@ export function Download() {
   );
 }
 
-async function retrieveContent(payloadCid: CID, provider: Multiaddr, extractContents: boolean = true): Promise<{ title: string, contents: Blob }> {
+async function retrieveContent(payloadCid: CID, provider: Multiaddr, extractContents = true): Promise<{ title: string, contents: Blob }> {
   // enable verbose logging in browser console to view debug logs
   enable("ui*,libp2p*,-libp2p:connection-manager*,helia*,helia*:trace,-*:trace");
 


### PR DESCRIPTION
Use react-router for routing. The current setup uses the router in [Data Mode](https://reactrouter.com/start/data/installation). I've tried to set it up in the [Framework Mode](https://reactrouter.com/start/framework/installation). There are soo many implicit things that I didn't manage to do that. For the time being, I think we can have it in Data Mode.