### PR TITLE
fix: handle disconnects from the WS

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -92,6 +92,14 @@ const Inner = ({ context }: { context: unknown }) => {
         </div>
       );
     }
+    case "disconnected": {
+      return (
+        <div className="bg-orange-50 text-center py-8 rounded-lg">
+          <Loader2 className="animate-spin mx-auto h-8 w-8 text-blue-500 mb-4" />
+          <p className="text-gray-600">Reconnecting to the collator at: {wsAddress}...</p>
+        </div>
+      );
+    }
     case "loaded":
     case "connected": {
       return <Outlet context={context} />;

--- a/src/GlobalCtxProvider.tsx
+++ b/src/GlobalCtxProvider.tsx
@@ -25,6 +25,10 @@ export function GlobalCtxProvider({
     const wsProvider = new WsProvider(wsAddress);
     wsProvider.on("connected", () => {
       console.log("WS ready!");
+
+      // The reason for setting `connecting` instead of connected is:
+      // When it's reconnected to ws, it isn't reconnected to the whole thing yet.
+      // subscribeFinalizedHeads method will execute and set to 'connected' when it's finished querying for the last block & friends.
       setStatus({ type: "connecting" });
     });
 

--- a/src/GlobalCtxProvider.tsx
+++ b/src/GlobalCtxProvider.tsx
@@ -8,6 +8,7 @@ export type Status =
   | { type: "connected" }
   | { type: "loading" }
   | { type: "loaded" }
+  | { type: "disconnected" }
   | { type: "failed"; error: string };
 
 export function GlobalCtxProvider({
@@ -22,6 +23,15 @@ export function GlobalCtxProvider({
 
   const connect = useCallback(async () => {
     const wsProvider = new WsProvider(wsAddress);
+    wsProvider.on("connected", () => {
+      console.log("WS ready!");
+      setStatus({ type: "connecting" });
+    });
+
+    wsProvider.on("disconnected", () => {
+      console.error("WS disconnected!");
+      setStatus({ type: "disconnected" });
+    });
 
     try {
       setStatus({ type: "connecting" });


### PR DESCRIPTION
It detects when we lost connection to the cluster and when it's up again, reconnects.