### PR TITLE
fix: use chain properties to get proper balance formatting

### DIFF
--- a/src/GlobalCtx.tsx
+++ b/src/GlobalCtx.tsx
@@ -1,7 +1,60 @@
 import type { ApiPromise, WsProvider } from "@polkadot/api";
 import type { TypeRegistry } from "@polkadot/types";
+import { formatBalance } from "@polkadot/util";
 import { createContext, useContext } from "react";
 import { GlobalCtxProvider, type Status } from "./GlobalCtxProvider";
+
+export class TokenProperties {
+  tokenSymbol: string;
+  tokenDecimals: number;
+
+  constructor(args: { tokenSymbol: string; tokenDecimals: number }) {
+    this.tokenSymbol = args.tokenSymbol;
+    this.tokenDecimals = args.tokenDecimals;
+  }
+
+  // `default` is a reserved keyword
+  static preset(): TokenProperties {
+    return new TokenProperties({
+      tokenSymbol: "UNIT",
+      tokenDecimals: 12,
+    });
+  }
+
+  /** Query the Polkadot API for the chain properties, will throw if either are missing */
+  static async fromApi(api: ApiPromise): Promise<TokenProperties> {
+    const systemProperties = await api.rpc.system.properties();
+    return new TokenProperties({
+      // We have a single token, hence the [0]
+      tokenDecimals: systemProperties.tokenDecimals.unwrap()[0].toNumber(),
+      tokenSymbol: systemProperties.tokenSymbol.unwrap()[0].toString(),
+    });
+  }
+
+  /** Converts a given value in the chain's respective UNIT to Plancks (amount denoted by the `tokenDecimals` field). */
+  unitToPlanck(unit: number): number {
+    return unit * this.tokenDecimals;
+  }
+
+  planckToUnit(planck: number): number {
+    return planck / this.tokenDecimals;
+  }
+
+  formatUnit(unit: number | bigint): string {
+    // 0 != BigInt(0) hence the ||
+    if (unit === 0 || (typeof unit === "bigint" && BigInt(0) === unit)) {
+      // 0 never gets a unit assigned to it
+      return `0 ${this.tokenSymbol}`;
+    }
+    // using `withSi: false` removes the unit,
+    // regardless of forceUnit
+    return formatBalance(unit, {
+      decimals: this.tokenDecimals,
+      forceUnit: this.tokenSymbol,
+      withZero: false,
+    });
+  }
+}
 
 export type Ctx = {
   registry: TypeRegistry;
@@ -10,6 +63,7 @@ export type Ctx = {
   collatorWsProvider: WsProvider | null;
   collatorWsApi: ApiPromise | null;
   collatorConnectionStatus: Status;
+  tokenProperties: TokenProperties;
 };
 
 export const GlobalCtx = createContext<Ctx | null>(null);

--- a/src/GlobalCtx.tsx
+++ b/src/GlobalCtx.tsx
@@ -32,8 +32,18 @@ export class TokenProperties {
   }
 
   /** Converts a given value in the chain's respective UNIT to Plancks (amount denoted by the `tokenDecimals` field). */
-  unitToPlanck(unit: number): number {
-    return unit * this.tokenDecimals;
+  unitToPlanck(unit: number | bigint): number {
+    const plancksPerUnit = 1 ** this.tokenDecimals;
+    const plancksPerUnitBI = BigInt(plancksPerUnit);
+    const valueBigInt = typeof unit === "number" ? BigInt(unit) : unit;
+
+    const whole = valueBigInt / plancksPerUnitBI;
+    const fraction = valueBigInt % plancksPerUnitBI;
+
+    const wholeNumber = Number(whole);
+    const fractionNumber = Number(fraction) / plancksPerUnit;
+
+    return wholeNumber + fractionNumber;
   }
 
   planckToUnit(planck: number): number {
@@ -41,8 +51,7 @@ export class TokenProperties {
   }
 
   formatUnit(unit: number | bigint): string {
-    // 0 != BigInt(0) hence the ||
-    if (unit === 0 || (typeof unit === "bigint" && BigInt(0) === unit)) {
+    if (unit === 0 || unit === 0n) {
       // 0 never gets a unit assigned to it
       return `0 ${this.tokenSymbol}`;
     }

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -1,4 +1,5 @@
 import { formatBalance } from "@polkadot/util";
+import { useCtx } from "../GlobalCtx";
 
 export namespace BalanceStatus {
   export function idle(): BalanceStatus {
@@ -38,6 +39,8 @@ export function Balance({
   status: BalanceStatus;
   balanceType: string;
 }) {
+  const { tokenProperties } = useCtx();
+
   if (status.state === BalanceState.Idle) return null;
 
   let balanceContent: React.ReactNode;
@@ -52,9 +55,7 @@ export function Balance({
       break;
 
     case BalanceState.Fetched:
-      balanceContent = (
-        <span>{formatBalance(status.value, { withUnit: false, withSi: false })} DOT</span>
-      );
+      balanceContent = <span>{tokenProperties.formatUnit(status.value)}</span>;
       break;
   }
 

--- a/src/components/Balance.tsx
+++ b/src/components/Balance.tsx
@@ -1,4 +1,3 @@
-import { formatBalance } from "@polkadot/util";
 import { useCtx } from "../GlobalCtx";
 
 export namespace BalanceStatus {

--- a/src/components/buttons/ProviderButton.tsx
+++ b/src/components/buttons/ProviderButton.tsx
@@ -1,6 +1,6 @@
 import { CheckCircle2, Circle, HelpCircle } from "lucide-react";
 import { Tooltip } from "react-tooltip";
-import { formatDot, planckToDot } from "../../lib/conversion";
+import { useCtx } from "../../GlobalCtx";
 import type { StorageProviderInfo } from "../../lib/storageProvider";
 
 type ProviderButtonProps = {
@@ -11,6 +11,7 @@ type ProviderButtonProps = {
 };
 
 export function ProviderButton({ accountId, provider, isSelected, onSelect }: ProviderButtonProps) {
+  const { tokenProperties } = useCtx();
   const peerId = provider.peerId;
   return (
     <button
@@ -51,8 +52,10 @@ export function ProviderButton({ accountId, provider, isSelected, onSelect }: Pr
               />
             </span>
             <span>
-              Price Per Block: {formatDot(planckToDot(provider.dealParams.minimumPricePerBlock))}{" "}
-              DOT
+              Price Per Block:{" "}
+              {tokenProperties.formatUnit(
+                tokenProperties.planckToUnit(provider.dealParams.minimumPricePerBlock),
+              )}
               <span id="tooltip-price" className="cursor-help inline-flex items-center ml-1">
                 <HelpCircle className="inline w-4 h-4 text-gray-400" />
               </span>

--- a/src/components/deal-proposal-form/DealProposalForm.tsx
+++ b/src/components/deal-proposal-form/DealProposalForm.tsx
@@ -6,7 +6,7 @@ import { useForm } from "react-hook-form";
 import { Toaster } from "react-hot-toast";
 import { z } from "zod";
 import { useCtx } from "../../GlobalCtx";
-import { blockToTime, formatDot, planckToDot } from "../../lib/conversion";
+import { blockToTime } from "../../lib/conversion";
 import { type StorageProviderInfo, isStorageProviderInfo } from "../../lib/storageProvider";
 import { Balance, BalanceStatus } from "../Balance";
 import Collapsible from "../Collapsible";
@@ -113,7 +113,7 @@ export function DealProposalForm({
     .map((p) => p.dealParams.minimumPricePerBlock * durationInBlocks)
     .reduce((a, b) => a + b, 0);
 
-  const { collatorWsApi: api } = useCtx();
+  const { collatorWsApi: api, tokenProperties } = useCtx();
   const client = watch("client");
   const [balanceStatus, setBalanceStatus] = useState<BalanceStatus>(BalanceStatus.idle);
 
@@ -230,7 +230,9 @@ export function DealProposalForm({
 
                 <p className="font-semibold text-sm">
                   Total Deal Price: <span className="text-blue-600">{totalPrice}</span> Planck (
-                  <span className="text-blue-600">{formatDot(planckToDot(totalPrice))}</span> DOT)
+                  <span className="text-blue-600">
+                    {tokenProperties.formatUnit(tokenProperties.planckToUnit(totalPrice))}
+                  </span>
                 </p>
               </div>
             )}

--- a/src/lib/conversion.ts
+++ b/src/lib/conversion.ts
@@ -1,14 +1,5 @@
 import { BLOCK_TIME } from "./consts";
 
-export function planckToDot(value: number): number {
-  const PLANCKS_PER_DOT = 10_000_000_000;
-  return value / PLANCKS_PER_DOT;
-}
-
-export function formatDot(value: number): string {
-  return value.toFixed(8).replace(/\.?0+$/, "");
-}
-
 export function blockToTime(
   block: number,
   currentBlock: number,


### PR DESCRIPTION
Correctly formats using the chain token symbol and decimals. This includes `0` which doesn't get a token symbol (I get why, I just disagree with parity's solution of not giving it one)

Fixes #62 

![Screenshot 2025-04-29 at 10-51-35 Delia](https://github.com/user-attachments/assets/23bb7709-9ffa-4346-96f3-2531d39cc05b)
![Screenshot 2025-04-29 at 10-51-42 Delia](https://github.com/user-attachments/assets/22a2272b-9951-49e2-9dd0-f43b5c7ee0b3)
![Screenshot 2025-04-29 at 10-51-50 Delia](https://github.com/user-attachments/assets/1f6072ad-63dc-488c-a024-778a1a46406f)
