### PR TITLE
refactor: Standardize toast notifications

### DIFF
--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,0 +1,25 @@
+import { toast } from "react-hot-toast";
+
+export function toastCustom(message: string, success: boolean) {
+  toast.custom(
+    (t) => (
+      <div className="bg-white shadow rounded px-4 py-2 flex items-start justify-between gap-4 max-w-sm border">
+        <div
+          className={`text-sm break-words whitespace-normal overflow-hidden text-ellipsis ${
+            success ? "text-green-700" : "text-red-700"
+          }`}
+        >
+          {message}
+        </div>
+        <button
+          type="button"
+          onClick={() => toast.dismiss(t.id)}
+          className="text-gray-500 hover:text-black text-sm"
+        >
+          ✖
+        </button>
+      </div>
+    ),
+    { duration: 5000 },
+  );
+}

--- a/src/components/Toast.tsx
+++ b/src/components/Toast.tsx
@@ -1,25 +1,38 @@
-import { toast } from "react-hot-toast";
+import type { ReactNode } from "react";
 
-export function toastCustom(message: string, success: boolean) {
-  toast.custom(
-    (t) => (
-      <div className="bg-white shadow rounded px-4 py-2 flex items-start justify-between gap-4 max-w-sm border">
-        <div
-          className={`text-sm break-words whitespace-normal overflow-hidden text-ellipsis ${
-            success ? "text-green-700" : "text-red-700"
-          }`}
-        >
-          {message}
-        </div>
-        <button
-          type="button"
-          onClick={() => toast.dismiss(t.id)}
-          className="text-gray-500 hover:text-black text-sm"
-        >
-          ✖
-        </button>
+export enum ToastState {
+  Loading = "loading",
+  Success = "success",
+  Error = "error",
+}
+
+export function ToastMessage({
+  message,
+  state,
+}: {
+  message: ReactNode;
+  state: ToastState;
+}) {
+  return (
+    <div className="px-4 py-2 flex items-start justify-between gap-4 max-w-sm">
+      <div
+        className={`text-sm break-words whitespace-normal overflow-hidden text-ellipsis ${getToastColour(
+          state,
+        )}`}
+      >
+        {message}
       </div>
-    ),
-    { duration: 5000 },
+    </div>
   );
+}
+
+function getToastColour(state: ToastState): string {
+  switch (state) {
+    case ToastState.Loading:
+      return "text-gray-700";
+    case ToastState.Success:
+      return "text-green-700";
+    case ToastState.Error:
+      return "text-red-700";
+  }
 }

--- a/src/components/account/FaucetPanel.tsx
+++ b/src/components/account/FaucetPanel.tsx
@@ -72,7 +72,10 @@ export function FaucetPanel({ selectedAddress, onSuccess }: FaucetPanelProps) {
           <ToastMessage message={`Faucet request failed: ${err}`} state={ToastState.Error} />
         ),
       },
-      { duration: 5000 },
+      {
+        duration: 5000, // applies to success and error
+        loading: { duration: Number.POSITIVE_INFINITY }, // keep loading toast visible until resolution
+      },
     );
   };
 

--- a/src/components/account/MarketDeposit.tsx
+++ b/src/components/account/MarketDeposit.tsx
@@ -57,7 +57,10 @@ export function MarketDeposit({ selectedAddress, walletBalance, onSuccess }: Mar
           <ToastMessage message={`Deposit failed: ${err}`} state={ToastState.Error} />
         ),
       },
-      { duration: 5000 },
+      {
+        duration: 5000, // applies to success and error
+        loading: { duration: Number.POSITIVE_INFINITY }, // keep loading toast visible until resolution
+      },
     );
 
     setDepositAmount(0n);

--- a/src/components/account/MarketDeposit.tsx
+++ b/src/components/account/MarketDeposit.tsx
@@ -2,6 +2,7 @@ import { useState } from "react";
 import { useCtx } from "../../GlobalCtx";
 import { sendTransaction } from "../../lib/sendTransaction";
 import { Transaction, TransactionState, type TransactionStatus } from "../../lib/transactionStatus";
+import { toastCustom } from "../Toast";
 
 interface MarketDepositProps {
   selectedAddress: string;
@@ -13,6 +14,7 @@ export function MarketDeposit({ selectedAddress, walletBalance, onSuccess }: Mar
   const { collatorWsApi: api, tokenProperties } = useCtx();
   const [depositAmount, setDepositAmount] = useState(0n);
   const [depositStatus, setDepositStatus] = useState<TransactionStatus>(Transaction.idle);
+  const [isFocused, setIsFocused] = useState(false);
 
   if (!api) {
     throw new Error("State hasn't been properly initialized");
@@ -31,7 +33,11 @@ export function MarketDeposit({ selectedAddress, walletBalance, onSuccess }: Mar
         // We just expose the onSuccess to the upper levels
         setDepositStatus(status);
         if (status.state === TransactionState.Success) {
+          toastCustom("✅ Market deposit successful!", true);
+          toastCustom(`Tx Hash: ${status.txHash}`, true);
           onSuccess();
+        } else if (status.state === TransactionState.Error) {
+          toastCustom(`⚠️ ${status.message}`, false);
         }
       },
     });
@@ -44,6 +50,10 @@ export function MarketDeposit({ selectedAddress, walletBalance, onSuccess }: Mar
     depositAmount <= 0n ||
     depositAmount > walletBalance;
 
+  const isZero = depositAmount <= 0n && isFocused;
+
+  const isTooLarge = depositAmount > 0n && BigInt(depositAmount) > walletBalance && isFocused;
+
   return (
     <div className="flex-1 min-w-0 flex flex-col gap-2">
       <h3 className="text-lg font-semibold">🛒 Deposit Market Balance</h3>
@@ -53,6 +63,8 @@ export function MarketDeposit({ selectedAddress, walletBalance, onSuccess }: Mar
           type="number"
           value={depositAmount.toString()}
           onChange={(e) => setDepositAmount(BigInt(e.target.value))}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
           placeholder="Amount in Planck"
           className="px-3 py-2 border rounded text-sm"
         />
@@ -73,31 +85,13 @@ export function MarketDeposit({ selectedAddress, walletBalance, onSuccess }: Mar
         </button>
       </div>
 
-      {depositAmount <= 0n && (
-        <p className="text-sm text-red-600">⚠️ Deposit value must be greater than 0.</p>
-      )}
+      {isZero && <p className="text-sm text-red-600">⚠️ Deposit value must be greater than 0.</p>}
 
-      {depositAmount > 0n && BigInt(depositAmount) > walletBalance && (
+      {isTooLarge && (
         <p className="text-sm text-red-600">
           ⚠️ You cannot deposit more than your available wallet balance.
         </p>
       )}
-
-      {(() => {
-        switch (depositStatus.state) {
-          case TransactionState.Success:
-            return (
-              <div className="text-sm text-green-600 space-y-1">
-                <p>✅ Market deposit successful!</p>
-                <p>Tx Hash: {depositStatus.txHash}</p>
-              </div>
-            );
-          case TransactionState.Error:
-            return <p className="text-sm text-red-600">⚠️ {depositStatus.message}</p>;
-          default:
-            return <></>;
-        }
-      })()}
     </div>
   );
 }

--- a/src/components/account/MarketWithdrawal.tsx
+++ b/src/components/account/MarketWithdrawal.tsx
@@ -63,7 +63,10 @@ export function MarketWithdrawal({
           <ToastMessage message={`Withdrawal failed: ${err}`} state={ToastState.Error} />
         ),
       },
-      { duration: 5000 },
+      {
+        duration: 5000, // applies to success and error
+        loading: { duration: Number.POSITIVE_INFINITY }, // keep loading toast visible until resolution
+      },
     );
 
     setWithdrawAmount(0n);

--- a/src/lib/sendTransaction.ts
+++ b/src/lib/sendTransaction.ts
@@ -2,7 +2,7 @@ import type { ApiPromise } from "@polkadot/api";
 import type { SubmittableExtrinsic } from "@polkadot/api/types";
 import { Transaction, type TransactionStatus } from "./transactionStatus";
 
-interface SendTransactionArgs {
+interface SignedTransactionArgs {
   api: ApiPromise;
   tx: SubmittableExtrinsic<"promise">;
   selectedAddress: string;
@@ -14,12 +14,15 @@ export async function sendTransaction({
   tx,
   selectedAddress,
   onStatusChange,
-}: SendTransactionArgs): Promise<string> {
-  return new Promise((resolve, reject) => {
+}: SignedTransactionArgs): Promise<string> {
+  // This functions flow is very similar to the sendUnsigned function.
+  // See the sendUnsigned function documentation for more information.
+  let unsubscribe: (() => void) | undefined;
+  const sendPromise: Promise<string> = new Promise((resolve, reject) => {
     onStatusChange(Transaction.loading());
 
     tx.signAndSend(selectedAddress, ({ status, dispatchError, txHash }) => {
-      if (!status.isInBlock && !status.isFinalized) return;
+      if (!status.isFinalized) return;
 
       try {
         if (!dispatchError) {
@@ -39,9 +42,82 @@ export async function sendTransaction({
       } catch (e) {
         reject(e);
       }
-    }).catch((err) => {
-      onStatusChange(Transaction.error("Transaction failed"));
-      reject(err);
-    });
+    })
+      .then((unsub) => {
+        unsubscribe = unsub;
+      })
+      .catch((err) => {
+        onStatusChange(Transaction.error("Transaction failed"));
+        reject(err);
+      });
   });
+
+  const finalTxHash = await sendPromise.finally(() => {
+    if (unsubscribe) {
+      unsubscribe();
+    }
+  });
+  return finalTxHash;
+}
+
+interface UnsignedTransactionArgs {
+  api: ApiPromise;
+  tx: SubmittableExtrinsic<"promise">;
+  onStatusChange: (status: TransactionStatus) => void;
+}
+
+export async function sendUnsigned({
+  api,
+  tx,
+  onStatusChange,
+}: UnsignedTransactionArgs): Promise<string> {
+  // let bind unsubscribe so we can assign it to the promise that tx.send returns.
+  // We need to unsub otherwise the transaction state gets fucked up.
+  // We only have undefined here to make sure tx.send's return gets assigned.
+  let unsubscribe: (() => void) | undefined;
+  // Create promise for sending so we can await within function scope
+  const sendPromise: Promise<string> = new Promise((sendResolve, sendReject) => {
+    onStatusChange(Transaction.loading());
+
+    tx.send(({ status, dispatchError, txHash }) => {
+      if (!status.isFinalized) return;
+
+      try {
+        if (!dispatchError) {
+          const txHashHex = txHash.toHex();
+          onStatusChange(Transaction.success(txHashHex));
+          sendResolve(txHashHex);
+        } else if (!dispatchError.isModule) {
+          const message = dispatchError.toString();
+          onStatusChange(Transaction.error(message));
+          sendReject(message);
+        } else {
+          const decoded = api.registry.findMetaError(dispatchError.asModule);
+          const userMessage = decoded.docs.join(" ") || `${decoded.section}.${decoded.name}`;
+          onStatusChange(Transaction.error(userMessage));
+          sendReject(userMessage);
+        }
+      } catch (e) {
+        sendReject(e);
+      }
+    })
+      .then((unsub) => {
+        // Assign unsubscribe to tx.send's returned promise.
+        // This will always happen, resulting in the unsubscribe never being undefined.
+        unsubscribe = unsub;
+      })
+      .catch((err) => {
+        onStatusChange(Transaction.error("Transaction failed"));
+        sendReject(err);
+      });
+  });
+
+  // Resolve the send promise and unsubscribe, this clears the txn state.
+  const txHash = await sendPromise.finally(() => {
+    // This should always be true because tx.send will always return a promise.
+    if (unsubscribe) {
+      unsubscribe();
+    }
+  });
+  return txHash;
 }

--- a/src/pages/DealPreparation.tsx
+++ b/src/pages/DealPreparation.tsx
@@ -6,6 +6,7 @@ import { Loader2 } from "lucide-react";
 import { toast } from "react-hot-toast";
 import { useOutletContext } from "react-router";
 import { useCtx } from "../GlobalCtx";
+import { ToastMessage, ToastState } from "../components/Toast";
 import {
   DealProposalForm,
   calculateStartEndBlocks,
@@ -170,18 +171,29 @@ export function DealPreparation() {
         return await performDeal(providerInfo, dealInfo);
       },
       {
-        loading: `Uploading deal to provider ${providerInfo.accountId}`,
-        error: (err) => (
-          <p>{`Failed to upload deal to provider ${providerInfo.accountId} with error: ${err}`}</p>
+        loading: (
+          <ToastMessage
+            message={`Uploading deal to provider ${providerInfo.accountId}`}
+            state={ToastState.Loading}
+          />
         ),
-        success: `Successfully uploaded deal to provider ${providerInfo.accountId}`,
+        error: (err) => (
+          <ToastMessage
+            message={
+              <p>{`Failed to upload deal to provider ${providerInfo.accountId} with error: ${err}`}</p>
+            }
+            state={ToastState.Error}
+          />
+        ),
+        success: (
+          <ToastMessage
+            message={`Successfully uploaded deal to provider ${providerInfo.accountId}`}
+            state={ToastState.Success}
+          />
+        ),
       },
       {
-        success: {
-          // Extend the duration to match the others
-          // so the user has more time to check successes
-          duration: 4000,
-        },
+        duration: 5000,
       },
     );
   };
@@ -239,8 +251,10 @@ export function DealPreparation() {
         createDownloadTrigger("deal.json", new Blob([JSON.stringify(submissionResults.toJSON())]));
       },
       {
-        loading: "Submitting deals!",
-        success: "Successfully submitted all deals!",
+        loading: <ToastMessage message={"Submitting deals!"} state={ToastState.Loading} />,
+        success: (
+          <ToastMessage message={"Successfully submitted all deals!"} state={ToastState.Success} />
+        ),
       },
     );
 

--- a/src/pages/DealPreparation.tsx
+++ b/src/pages/DealPreparation.tsx
@@ -193,7 +193,8 @@ export function DealPreparation() {
         ),
       },
       {
-        duration: 5000,
+        duration: 5000, // applies to success and error
+        loading: { duration: Number.POSITIVE_INFINITY }, // keep loading toast visible until resolution
       },
     );
   };

--- a/src/pages/Download.tsx
+++ b/src/pages/Download.tsx
@@ -133,7 +133,7 @@ export function Download() {
           text={isDownloading ? "Downloading..." : "Download"}
         />
       </div>
-      <Toaster position="top-center" reverseOrder={true} />
+      <Toaster position="bottom-left" reverseOrder={true} />
     </>
   );
 }

--- a/src/pages/Download.tsx
+++ b/src/pages/Download.tsx
@@ -6,6 +6,7 @@ import { Tooltip } from "react-tooltip";
 import { ZodError } from "zod";
 import { useCtx } from "../GlobalCtx";
 import { ReceiptUploader } from "../components/ReceiptUploader";
+import { ToastMessage, ToastState } from "../components/Toast";
 import { DownloadButton } from "../components/buttons/DownloadButton";
 import { createDownloadTrigger } from "../lib/download";
 import { resolvePeerIdMultiaddrs } from "../lib/resolvePeerIdMultiaddr";
@@ -84,7 +85,9 @@ export function Download() {
   const download = async () => {
     setIsDownloading(true);
     try {
-      await toast.promise(downloadInner(), { loading: "Downloading file!" });
+      await toast.promise(downloadInner(), {
+        loading: <ToastMessage message={"Downloading file!"} state={ToastState.Loading} />,
+      });
     } finally {
       setIsDownloading(false);
     }


### PR DESCRIPTION
This PR update feedback across the app to use a consistent, styled toast built with `react-hot-toast`.

- Introduces a shared ToastMessage component with support for success, error, and loading states.

- Replaces inline messages and toastCustom calls with toast.promise for better user experience and centralized control.

- Displays transaction hashes in success messages where relevant.

- Refactors sendTransaction to return the transaction hash on success and simplify error handling.

- Updates existing toast usage in deal preparation and file downloads to use the new ToastMessage component.

- Sets toast duration to 5 seconds and ensures messages are styled to fit without overflow.

These changes improve clarity and consistency in how users receive feedback for transactions like faucet requests, deposits, withdrawals, and deal submissions.


https://github.com/user-attachments/assets/e756b513-eb62-41f7-a72e-152c062e25d8
