### PR TITLE
feat: persist wsAddress via global context

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -8,18 +8,18 @@ import { GlobalCtxProvider } from "./GlobalCtxProvider";
 import { ConnectWallet } from "./components/ConnectWallet";
 import { NavDropdown } from "./components/NavDropdown";
 import Toaster from "./components/Toaster";
-import { COLLATOR_LOCAL_RPC_URL } from "./lib/consts";
 import { setupTypeRegistry } from "./lib/registry";
 
-function WsAddressInput({ onChange }: { onChange: (newValue: string) => void }) {
-  const [wsAddress, setWsAddress] = useState(() => {
-    // Check localStorage first, fall back to default
-    return localStorage.getItem("wsAddress") || COLLATOR_LOCAL_RPC_URL;
-  });
+function WsAddressInput() {
+  const { wsAddress, setWsAddress } = useCtx();
 
+  // We use a local state copy so users can type freely
+  // without triggering a reconnect on every keystroke.
+  const [localValue, setLocalValue] = useState(wsAddress);
+
+  // Keep localValue in sync with context if it changes externally
   useEffect(() => {
-    // Save value to localStorage whenever it changes
-    localStorage.setItem("wsAddress", wsAddress);
+    setLocalValue(wsAddress);
   }, [wsAddress]);
 
   return (
@@ -30,16 +30,17 @@ function WsAddressInput({ onChange }: { onChange: (newValue: string) => void }) 
       <input
         id="ws-address"
         type="text"
-        className="p-1 border rounded  focus:ring-blue-500 focus:border-blue-500 mr-2"
-        value={wsAddress}
-        onChange={(e) => setWsAddress(e.target.value)}
+        className="p-1 border rounded focus:ring-blue-500 focus:border-blue-500 mr-2"
+        value={localValue}
+        onChange={(e) => setLocalValue(e.target.value)}
       />
       <button
         type="submit"
         className="transition-colors hover:text-blue-400"
-        onClick={(_) => {
-          onChange(wsAddress);
+        onClick={() => {
+          setWsAddress(localValue); // Triggers reconnection
         }}
+        title="Connect"
       >
         <RefreshCw />
       </button>
@@ -51,15 +52,6 @@ function App() {
   const [accounts, setAccounts] = useState<InjectedAccountWithMeta[]>([]);
   const [selectedAccount, setSelectedAccount] = useState<InjectedAccountWithMeta | null>(null);
   const [loaded, setLoaded] = useState<boolean>(false);
-  const [wsAddress, setWsAddress] = useState(() => {
-    // Check localStorage first, fall back to default
-    return localStorage.getItem("wsAddress") || COLLATOR_LOCAL_RPC_URL;
-  });
-
-  useEffect(() => {
-    // Save value to localStorage whenever it changes
-    localStorage.setItem("wsAddress", wsAddress);
-  }, [wsAddress]);
 
   const registry = useMemo(() => setupTypeRegistry(), []);
 
@@ -84,14 +76,14 @@ function App() {
     );
 
   return (
-    <GlobalCtxProvider registry={registry} wsAddress={wsAddress}>
+    <GlobalCtxProvider registry={registry}>
       <div className="m-8">
         <div className="flex mb-4 items-center">
           <h1 className="grow text-xl font-bold">📦 Delia</h1>
           <div className="relative mr-6">
             <NavDropdown />
           </div>
-          <WsAddressInput onChange={setWsAddress} />
+          <WsAddressInput />
         </div>
         {accounts.length === 0 ? (
           <ConnectWallet onConnect={setAccounts} />

--- a/src/GlobalCtx.tsx
+++ b/src/GlobalCtx.tsx
@@ -78,6 +78,7 @@ export class TokenProperties {
 export type Ctx = {
   registry: TypeRegistry;
   wsAddress: string;
+  setWsAddress: (newValue: string) => void;
   latestFinalizedBlock: { number: number; timestamp: Date } | null;
   collatorWsProvider: WsProvider | null;
   collatorWsApi: ApiPromise | null;

--- a/src/GlobalCtxProvider.tsx
+++ b/src/GlobalCtxProvider.tsx
@@ -2,6 +2,7 @@ import { ApiPromise, WsProvider } from "@polkadot/api";
 import type { TypeRegistry, u64 } from "@polkadot/types";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { GlobalCtx, TokenProperties } from "./GlobalCtx";
+import { COLLATOR_LOCAL_RPC_URL } from "./lib/consts";
 
 export type Status =
   | { type: "connecting" }
@@ -12,10 +13,16 @@ export type Status =
   | { type: "failed"; error: string };
 
 export function GlobalCtxProvider({
-  wsAddress,
   registry,
   children,
-}: React.PropsWithChildren<{ registry: TypeRegistry; wsAddress: string }>) {
+}: React.PropsWithChildren<{ registry: TypeRegistry }>) {
+  const [wsAddress, setWsAddress] = useState(() => {
+    return localStorage.getItem("wsAddress") || COLLATOR_LOCAL_RPC_URL;
+  });
+
+  useEffect(() => {
+    localStorage.setItem("wsAddress", wsAddress);
+  }, [wsAddress]);
   const collatorWsProviderRef = useRef<WsProvider | null>(null);
   const collatorWsRef = useRef<ApiPromise | null>(null);
   const [status, setStatus] = useState<Status>({ type: "connecting" });
@@ -104,6 +111,7 @@ export function GlobalCtxProvider({
     () => ({
       registry,
       wsAddress,
+      setWsAddress,
       latestFinalizedBlock:
         latestFinalizedBlock && latestBlockTimestamp
           ? { number: latestFinalizedBlock, timestamp: latestBlockTimestamp }

--- a/src/components/deal-proposal-form/ProviderSelector.tsx
+++ b/src/components/deal-proposal-form/ProviderSelector.tsx
@@ -4,7 +4,6 @@ import { AlertCircle, Loader2, RefreshCw, Server } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { type Control, Controller, type Path } from "react-hook-form";
 import { useCtx } from "../../GlobalCtx";
-import { COLLATOR_LOCAL_RPC_URL } from "../../lib/consts";
 import {
   type DealParams,
   type StorageProviderInfo,
@@ -49,7 +48,7 @@ type ProviderSelectorProps = {
 };
 
 const NoProviders = () => {
-  const wsAddress = localStorage.getItem("wsAddress") || COLLATOR_LOCAL_RPC_URL;
+  const { wsAddress } = useCtx();
   return (
     <div className="text-center py-8 border-2 border-dashed border-gray-300 rounded-lg">
       <Server className="mx-auto h-12 w-12 text-gray-400 mb-2" />


### PR DESCRIPTION
## TL;DR

Moves `wsAddress` into global context, improves persistence, and avoids reconnecting on every keystroke.

---

## Summary

This PR improves how the `wsAddress` is managed throughout the app by:

- **Lifting `wsAddress` into global context** (`GlobalCtx`) and exposing it via `useCtx()`, including a `setWsAddress` function.
- **Persisting `wsAddress` to `localStorage`**, allowing the user’s last-used endpoint to survive page reloads and hot reloads.
- **Refactoring the `WsAddressInput` component** to:
  - Use local input state to prevent reconnecting on every keystroke.
  - Commit changes to the global context only when the refresh button is clicked.
- **Cleaning up the `App.tsx` component** by removing its local `wsAddress` state.
- **Updating `NoProviders`** to read from context instead of directly from `localStorage`, ensuring consistent display of the active endpoint.

These changes make the endpoint selection UX smoother and more React-idiomatic, while simplifying global access to the currently selected collator node.

> 💡 **Future improvement**: include `wsAddress` in the URL so that links with prefilled endpoints can be shared directly.
