### PR TITLE
feat: provide more info on deal duration

### DIFF
--- a/src/lib/conversion.ts
+++ b/src/lib/conversion.ts
@@ -10,3 +10,53 @@ export function blockToTime(
 
   return realTime;
 }
+
+export function secondsToDuration(seconds: number): {
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+} {
+  const MINUTE_IN_SECONDS = 60;
+  const HOUR_IN_SECONDS = 60 * MINUTE_IN_SECONDS;
+  const DAY_IN_SECONDS = 24 * HOUR_IN_SECONDS;
+  if (seconds < MINUTE_IN_SECONDS) {
+    return { seconds };
+  }
+  if (seconds < HOUR_IN_SECONDS) {
+    const m = Math.floor(seconds / MINUTE_IN_SECONDS);
+    const s = seconds - m * MINUTE_IN_SECONDS;
+    return { minutes: m, seconds: s };
+  }
+  if (seconds < DAY_IN_SECONDS) {
+    let remaining = seconds;
+    const h = Math.floor(remaining / HOUR_IN_SECONDS);
+    remaining -= h * HOUR_IN_SECONDS;
+    const m = Math.floor(remaining / MINUTE_IN_SECONDS);
+    remaining -= m * MINUTE_IN_SECONDS;
+    return { hours: h, minutes: m, seconds: remaining };
+  }
+  let remaining = seconds;
+  const d = Math.floor(remaining / DAY_IN_SECONDS);
+  remaining -= d * DAY_IN_SECONDS;
+  const h = Math.floor(remaining / HOUR_IN_SECONDS);
+  remaining -= h * HOUR_IN_SECONDS;
+  const m = Math.floor(remaining / MINUTE_IN_SECONDS);
+  remaining -= m * MINUTE_IN_SECONDS;
+  return { days: d, hours: h, minutes: m, seconds: remaining };
+}
+
+export function formatDuration(duration: {
+  days?: number;
+  hours?: number;
+  minutes?: number;
+  seconds?: number;
+}) {
+  const result = [];
+  for (const [k, v] of Object.entries(duration)) {
+    if (v && v !== 0) {
+      result.push(`${v} ${k}`);
+    }
+  }
+  return `${result.join(", ")}`;
+}


### PR DESCRIPTION
Solves:

> nit UI comment:
Maybe that text can be updated to:
Deal 12: active since block 4119, available for retrieval for the next XXX blocks.
Then it's gonna be fully clear (or specify time and date instead of blocks)