### PR TITLE
fix: tooltip selector in DisabledInputInfo to match rendered ID

### DIFF
--- a/src/components/deal-proposal-form/DisabledInputInfo.tsx
+++ b/src/components/deal-proposal-form/DisabledInputInfo.tsx
@@ -19,7 +19,7 @@ export const DisabledInputInfo = ({
             <span id={`tooltip-${name}`} className="cursor-help inline-flex items-center ml-1">
               <HelpCircle className="inline w-4 h-4 text-gray-400" />
             </span>
-            <Tooltip anchorSelect={`#tooltip-${name}-cid`} content={tooltip} />
+            <Tooltip anchorSelect={`#tooltip-${name}`} content={tooltip} />
           </>
         )}
       </label>


### PR DESCRIPTION
This PR fixes a bug in the `DisabledInputInfo` component where tooltips were not showing up due to a mismatch between the id assigned to the tooltip anchor and the `anchorSelect` used in the `<Tooltip>` component.

Updated anchorSelect from `#tooltip-${name}-cid` to match the actual rendered id: `#tooltip-${name}`.

This resolves the issue where tooltips were not appearing in the UI, including inside collapsible sections.

![image](https://github.com/user-attachments/assets/d9a1b3cc-0aa1-4a59-b1bb-098f5098033b)