### PR TITLE
fix: strip leading underscore from sectorSize display

### DIFF
--- a/src/components/buttons/ProviderButton.tsx
+++ b/src/components/buttons/ProviderButton.tsx
@@ -49,7 +49,7 @@ export function ProviderButton({ accountId, provider, isSelected, onSelect }: Pr
             <Tooltip anchorSelect={`#peer-id-tooltip-${accountId}`} content={peerId} />
 
             <span>
-              Sector Size: {provider.sectorSize} bytes
+              Sector Size: {provider.sectorSize.replace(/^_/, "")} bytes
               <span id="tooltip-sector-size" className="cursor-help inline-flex items-center ml-1">
                 <HelpCircle className="inline w-4 h-4 text-gray-400" />
               </span>

--- a/src/components/buttons/ProviderButton.tsx
+++ b/src/components/buttons/ProviderButton.tsx
@@ -49,7 +49,7 @@ export function ProviderButton({ accountId, provider, isSelected, onSelect }: Pr
             <Tooltip anchorSelect={`#peer-id-tooltip-${accountId}`} content={peerId} />
 
             <span>
-              Sector Size: {provider.sectorSize.replace(/^_/, "")} bytes
+              Sector Size: {provider.sectorSize.replace(/^_/, "")}
               <span id="tooltip-sector-size" className="cursor-help inline-flex items-center ml-1">
                 <HelpCircle className="inline w-4 h-4 text-gray-400" />
               </span>


### PR DESCRIPTION
This PR ensures that a leading underscore is removed from `provider.sectorSize` before rendering, fixing cases where sector sizes were displayed with a `_` prefix.

Also removes the `bytes` after the sector size because of double information, the `B` in `MiB` also stands for bytes

![image](https://github.com/user-attachments/assets/00daf2af-4db2-47f5-803f-5584042055c1)

![image](https://github.com/user-attachments/assets/57f0c589-61e2-441f-a93d-8a06b32d5334)
