### PR TITLE
fix: prevent polling loop when no accounts are available

### DIFF
--- a/src/components/ConnectWallet.tsx
+++ b/src/components/ConnectWallet.tsx
@@ -62,7 +62,7 @@ export function ConnectWallet({
   }, [onConnect, state]);
 
   useEffect(() => {
-    if (connectedAccounts) return;
+    if (connectedAccounts || error) return;
 
     setState(ConnectState.Polling);
 
@@ -89,7 +89,7 @@ export function ConnectWallet({
     return () => {
       if (intervalId) clearInterval(intervalId);
     };
-  }, [connectedAccounts, connect]);
+  }, [connectedAccounts, connect, error]);
 
   const renderError = () => {
     if (error === WalletError.NoExtension) {


### PR DESCRIPTION
Stops the `ConnectWallet` component from repeatedly polling when the extension is installed but no accounts are authorized. Adds an `error` dependency check to exit the polling loop on error.
